### PR TITLE
optimized cp(), 2x performance increase for large files

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -92,8 +92,12 @@ func (d *decoder) readUint16() (uint16, error) {
 
 func (d *decoder) cp(length, decr uint32) {
 	// can't use copy here, but could probably optimize the appends
-	for ii := uint32(0); ii < length; ii++ {
-		d.dst = append(d.dst, d.dst[d.ref+ii])
+	if int(d.ref)+int(length)-len(d.dst) > 0 {
+		for ii := uint32(0); ii < length; ii++ {
+			d.dst = append(d.dst, d.dst[d.ref+ii])
+		}
+	} else {
+		d.dst = append(d.dst, d.dst[d.ref:d.ref+length]...)
 	}
 	d.dpos += length
 	d.ref += length - decr


### PR DESCRIPTION
AFAICT, cp() needs to append byte by byte because initially there may not be enough in the dst to cover the length requested. But once there's enough in dst, you can just append a whole slice.
