### PR TITLE
Use capacity to determine whether dst can be reused for encoding and decoding

### DIFF
--- a/lz4_test.go
+++ b/lz4_test.go
@@ -46,18 +46,27 @@ func TestWords(t *testing.T) {
 }
 
 func BenchmarkLZ4Encode(b *testing.B) {
+	var dst []byte
+	var err error
+
 	for i := 0; i < b.N; i++ {
-		Encode(nil, testfile)
+		dst, err = Encode(dst, testfile)
+		if err != nil {
+			b.Fatalf("Error while encoding: %v", err)
+		}
 	}
 }
 
 func BenchmarkLZ4Decode(b *testing.B) {
-
 	var compressed, _ = Encode(nil, testfile)
+	var dst []byte
+	var err error
 
 	b.ResetTimer()
-
 	for i := 0; i < b.N; i++ {
-		Decode(nil, compressed)
+		dst, err = Decode(dst, compressed)
+		if err != nil {
+			b.Fatalf("Error while decoding: %v", err)
+		}
 	}
 }

--- a/reader.go
+++ b/reader.go
@@ -118,7 +118,7 @@ func Decode(dst, src []byte) ([]byte, error) {
 		return nil, ErrTooLarge
 	}
 
-	if dst == nil || len(dst) < int(uncompressedLen) {
+	if dst == nil || cap(dst) < int(uncompressedLen) {
 		dst = make([]byte, uncompressedLen)
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -108,8 +108,10 @@ func Encode(dst, src []byte) ([]byte, error) {
 		return nil, ErrTooLarge
 	}
 
-	if n := CompressBound(len(src)); len(dst) < n {
+	if n := CompressBound(len(src)); cap(dst) < n {
 		dst = make([]byte, n)
+	} else {
+		dst = dst[:n]
 	}
 
 	e := encoder{src: src, dst: dst, hashTable: make([]uint32, hashTableSize)}


### PR DESCRIPTION
Also, modify the benchmarks to reuse the allocated slice. This improves the ns/op for both encoding and decoding by 0.4s/op (2.4s -> 2.0s for Decode, and similar for encode).